### PR TITLE
Add MidA's own base and section templates for CMS structure

### DIFF
--- a/mida/templates/cms/base.html
+++ b/mida/templates/cms/base.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block templatename %}
+    {{ block.super }}
+    <!-- BASE: mida-portal/templates/cms/base.html -->
+{% endblock templatename %}
+
+{% block body_class %}mida-cms-base {{ self.get_verbose_name|slugify }}-page{% endblock %}

--- a/mida/templates/cms/section.html
+++ b/mida/templates/cms/section.html
@@ -1,0 +1,37 @@
+{% extends "cms/base.html" %}
+{% load wagtailcore_tags wagtailcustom_tags %}
+
+<!-- mida-portal/templates/cms/section.html -->
+
+{% block layout %}section{% endblock %}
+
+{% block page_header %}
+
+    <div class="title-line">
+	    {% block title %}<h1>{{ self.title }}</h1>{% endblock %}
+    </div>
+
+    {% if self.description %}
+	    <div class="description">
+		    {{ self.description|anchored_richtext }}
+	    </div>
+    {% endif %}
+
+{% endblock %}
+
+{% block content %}
+
+  {% for block in page.body %}
+    {% if block.block_type == 'table' %}
+        {% include_block block %}
+    {% elif block.block_type == 'text' %}
+        <div class="page-body">
+          {% include_block block %}
+        </div>
+    {% else %}
+      {# rendering for other block types #}
+      {% include_block block %}
+    {% endif %}
+  {% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
This pull request introduces new base and section templates for the CMS, establishing a template inheritance structure and setting up consistent blocks for page layout and content rendering. The changes improve template organization and provide a clear structure for extending and customizing CMS pages.

**Template structure and inheritance:**

* Added a new `cms/base.html` template that extends `base.html`, defines a `templatename` block for template identification, and sets a dynamic `body_class` using the page's verbose name.
* Created a new `cms/section.html` template that extends `cms/base.html`, loads necessary template tags, and defines key blocks for layout, page header (including title and description), and content.

**Content rendering improvements:**

* Implemented logic in `cms/section.html` to render different block types (`table`, `text`, and others) from the page body, allowing for flexible and modular content display.