### PR TITLE
Survey module

### DIFF
--- a/mida/local_settings.py.template
+++ b/mida/local_settings.py.template
@@ -1,5 +1,6 @@
 ARCGIS_API_KEY = "set in local settings"
 
+# Defines which apps/modules interact with the MyPlanner tab in mp-visualize's left nav
 PLANNER_APPS = [
     'visualize',
     'drawing',

--- a/mida/local_settings.py.template
+++ b/mida/local_settings.py.template
@@ -1,1 +1,7 @@
 ARCGIS_API_KEY = "set in local settings"
+
+PLANNER_APPS = [
+    'visualize',
+    'drawing',
+    'survey',
+]

--- a/mida/settings.py
+++ b/mida/settings.py
@@ -51,7 +51,7 @@ ARCGIS_API_KEY = "set in local settings"
 PLANNER_APPS = [
     'visualize',
     'drawing',
-    'survey',
+    # 'survey',
 ]
 
 try:

--- a/mida/settings.py
+++ b/mida/settings.py
@@ -48,6 +48,9 @@ TEMPLATES = [
 SUPPORT_INVERTED_COORDINATES = False
 ARCGIS_API_KEY = "set in local settings"
 
+# Defines which apps/modules interact with the MyPlanner tab in mp-visualize's left nav
+# Add 'survey' to this list once Surveys are live on MidA production
+# see https://github.com/Ecotrust/mp-visualize/wiki for more info
 PLANNER_APPS = [
     'visualize',
     'drawing',

--- a/mida/settings.py
+++ b/mida/settings.py
@@ -48,6 +48,12 @@ TEMPLATES = [
 SUPPORT_INVERTED_COORDINATES = False
 ARCGIS_API_KEY = "set in local settings"
 
+PLANNER_APPS = [
+    'visualize',
+    'drawing',
+    'survey',
+]
+
 try:
     from .local_settings import *
 except ImportError:


### PR DESCRIPTION
Simple change to add `PLANNER_APPS` setting to allow users to define which modules will interact with the MyPlanner tab in `mp-visualize`'s left nav.

This setting is set in the updated mp-visualize module, but once Surveys are live on MidA production, we want to permanently override this setting.