### PR TITLE
Redesign Create Map Group

### DIFF
--- a/mida/static/mida/css/globals.css
+++ b/mida/static/mida/css/globals.css
@@ -250,3 +250,29 @@ strong {
     opacity: 0.75;
     text-decoration: none;
 }
+
+.button-small {
+    align-items: center;
+    background: var(--yellow-bright);
+    border: none;
+    border-radius: 8px;
+    color: var(--white);
+    display: flex;
+    font-family: var(--h7-font-family);
+    font-size: var(--h7-font-size);
+    font-style: var(--h7-font-style);
+    font-weight: var(--h7-font-weight);
+    justify-content: center;
+    letter-spacing: var(--h7-letter-spacing);
+    line-height: var(--h7-line-height);
+    padding: 12px 24px;
+    position: relative;
+    text-transform: uppercase;
+    width: fit-content;
+}
+
+.button-small.property-outline {
+    background: transparent;
+    border: 1px solid var(--dark-blue);
+    color: var(--dark-blue);
+}

--- a/mida/static/mida/css/globals.css
+++ b/mida/static/mida/css/globals.css
@@ -226,6 +226,7 @@ strong {
 .button-big {
     align-items: center;
     background-color: var(--yellow-bright);
+    border: none;
     border-radius: 10px;
     color: var(--white);
     display: flex;

--- a/mida/static/mida/mapgroups/mapgroup_form.css
+++ b/mida/static/mida/mapgroups/mapgroup_form.css
@@ -1,0 +1,59 @@
+h2 {
+    color: var(--teal);
+    text-align: center;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  margin: 0 auto;
+  width: 80%;
+}
+
+.form-row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.form-row > label {
+    font-family: var(--FAQ-headline-font-family);
+    font-size: var(--FAQ-headline-font-size);
+    line-height: var(--FAQ-headline-line-height);
+    font-weight: var(--FAQ-headline-font-weight);
+    color: var(--dark-blue);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field--toggle .toggle-options {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.field-tip {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.form-actions {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.form-actions .button-big {
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .form-row {
+    grid-template-columns: 200px minmax(0, 1fr);
+    align-items: start;
+  }
+}

--- a/mida/static/mida/mapgroups/mapgroup_form.css
+++ b/mida/static/mida/mapgroups/mapgroup_form.css
@@ -1,9 +1,9 @@
-h2 {
+.create-map-group h2 {
     color: var(--teal);
     text-align: center;
 }
 
-.form-grid {
+.create-map-group .form-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1.5rem;
@@ -11,12 +11,12 @@ h2 {
   width: 80%;
 }
 
-.form-row {
+.create-map-group .form-row {
   display: grid;
   gap: 0.5rem;
 }
 
-.form-row > label {
+.create-map-group .form-row > label {
     font-family: var(--FAQ-headline-font-family);
     font-size: var(--FAQ-headline-font-size);
     line-height: var(--FAQ-headline-line-height);
@@ -24,35 +24,35 @@ h2 {
     color: var(--dark-blue);
 }
 
-.form-field {
+.create-map-group .form-field {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.form-field--toggle .toggle-options {
+.create-map-group .form-field--toggle .toggle-options {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.field-tip {
+.create-map-group .field-tip {
   margin: 0;
   font-size: 0.9rem;
   color: #6b7280;
 }
 
-.form-actions {
+.create-map-group .form-actions {
   margin-top: 2rem;
   text-align: center;
 }
 
-.form-actions .button-big {
+.create-map-group .form-actions .button-big {
   margin: 0 auto;
 }
 
 @media (min-width: 768px) {
-  .form-row {
+  .create-map-group .form-row {
     grid-template-columns: 200px minmax(0, 1fr);
     align-items: start;
   }

--- a/mida/templates/mapgroups/mapgroup_form.html
+++ b/mida/templates/mapgroups/mapgroup_form.html
@@ -13,63 +13,66 @@
 
 {% block content %}
 
-    <div class="contain">
-        <h2>Create a map group</h2>
-        <div class="group-form-disclaimer">
-            <p><i>*Note: MARCO reserves the right to review and remove Groups and content shared within them due to inactivity, inappropriate content or other misuse.</i></p>
+    <section class="create-map-group">
+        <div class="create-map-group contain">
+            <h2>Create a map group</h2>
+            <div class="group-form-disclaimer">
+                <p><i>*Note: MARCO reserves the right to review and remove Groups and content shared within them due to inactivity, inappropriate content or other misuse.</i></p>
+            </div>
         </div>
-    </div>
-    <div class="bg-light-blue contain contain-padded">
-        <form class="create-group-form" method="POST" enctype="multipart/form-data">
-            {% csrf_token %}
-            <div class="form-grid">
-                <div class="form-row">
-                    <label for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
-                    <div class="form-field">
-                        {{ form.name }}
-                        {{ form.name.errors }}
-                    </div>
-                </div>
 
-                <div class="form-row">
-                    <label>Group Type</label>
-                    <div class="form-field form-field--toggle">
-                        <div class="toggle-options">
-                            <input id="id_is_open" name="is_open"
-                                    type="checkbox" checked="checked"
-                                    data-toggle="toggle" data-on="Public"
-                                    data-off="Private"
-                                    data-onstyle="success"
-                                    data-offstyle="danger">
+        <div class="bg-light-blue contain contain-padded">
+            <form class="create-group-form" method="POST" enctype="multipart/form-data">
+                {% csrf_token %}
+                <div class="form-grid">
+                    <div class="form-row">
+                        <label for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
+                        <div class="form-field">
+                            {{ form.name }}
+                            {{ form.name.errors }}
                         </div>
-                        {{ form.is_open.errors }}
-                        <p class="field-tip">Tip: Anyone can join a public group. Group owners approve private group membership requests.</p>
+                    </div>
+
+                    <div class="form-row">
+                        <label>Group Type</label>
+                        <div class="form-field form-field--toggle">
+                            <div class="toggle-options">
+                                <input id="id_is_open" name="is_open"
+                                        type="checkbox" checked="checked"
+                                        data-toggle="toggle" data-on="Public"
+                                        data-off="Private"
+                                        data-onstyle="success"
+                                        data-offstyle="danger">
+                            </div>
+                            {{ form.is_open.errors }}
+                            <p class="field-tip">Tip: Anyone can join a public group. Group owners approve private group membership requests.</p>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <label for="{{ form.blurb.id_for_label }}">Description</label>
+                        <div class="form-field">
+                            {{ form.blurb }}
+                            {{ form.blurb.errors }}
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <label for="{{ form.image.id_for_label }}">{{ form.image.label }}</label>
+                        <div class="form-field">
+                            {{ form.image }}<br>
+                            {{ form.image.errors }}
+                            <p class="field-tip">Tip: the best image sizes are 345x195 or larger.</p>
+                        </div>
                     </div>
                 </div>
 
-                <div class="form-row">
-                    <label for="{{ form.blurb.id_for_label }}">Description</label>
-                    <div class="form-field">
-                        {{ form.blurb }}
-                        {{ form.blurb.errors }}
-                    </div>
+                <div class="form-actions">
+                    <button class="button-big" type="submit">Create Group</button>
                 </div>
-
-                <div class="form-row">
-                    <label for="{{ form.image.id_for_label }}">{{ form.image.label }}</label>
-                    <div class="form-field">
-                        {{ form.image }}<br>
-                        {{ form.image.errors }}
-                        <p class="field-tip">Tip: the best image sizes are 345x195 or larger.</p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="form-actions">
-                <button class="button-big" type="submit">Create Group</button>
-            </div>
-        </form>
-    </div>
+            </form>
+        </div>
+    </section>
 {% endblock %}
 
 {% block extra_js %}

--- a/mida/templates/mapgroups/mapgroup_form.html
+++ b/mida/templates/mapgroups/mapgroup_form.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block page_header %}
-    <a class="btn btn-success" href="{% url 'mapgroups:list'%}">&larr; Groups</a>
+    <a class="button-small property-outline" href="{% url 'mapgroups:list'%}">Back to Groups</a>
 {% endblock %}
 
 {% block content %}

--- a/mida/templates/mapgroups/mapgroup_form.html
+++ b/mida/templates/mapgroups/mapgroup_form.html
@@ -5,6 +5,7 @@
   {{ block.super }}
   <link href="{% static '/mapgroups/assets/bootstrap-toggle-master/css/bootstrap-toggle.min.css' %}" rel="stylesheet">
   <link href="{% static '/mapgroups/css/create_map_group_form.css' %}" rel="stylesheet">
+  <link href="{% static 'mida/mapgroups/mapgroup_form.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block page_header %}

--- a/mida/templates/mapgroups/mapgroup_form.html
+++ b/mida/templates/mapgroups/mapgroup_form.html
@@ -4,7 +4,6 @@
 {% block extra_css %}
   {{ block.super }}
   <link href="{% static '/mapgroups/assets/bootstrap-toggle-master/css/bootstrap-toggle.min.css' %}" rel="stylesheet">
-  <link href="{% static '/mapgroups/css/create_map_group_form.css' %}" rel="stylesheet">
   <link href="{% static 'mida/mapgroups/mapgroup_form.css' %}" rel="stylesheet">
 {% endblock %}
 
@@ -14,80 +13,65 @@
 
 {% block content %}
 
-<div>
-    <h2 style="text-align: center;">Create a map group</h2>
-    <div>
-        <hr />
+    <div class="contain">
+        <h2>Create a map group</h2>
         <div class="group-form-disclaimer">
-          <p><i>*Note: MARCO reserves the right to review and remove Groups and content shared within them due to inactivity, inappropriate content or other misuse.</i></p>
+            <p><i>*Note: MARCO reserves the right to review and remove Groups and content shared within them due to inactivity, inappropriate content or other misuse.</i></p>
         </div>
-
-        <form class="login-form" method="POST" enctype="multipart/form-data">
+    </div>
+    <div class="bg-light-blue contain contain-padded">
+        <form class="create-group-form" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
-            <div class="form-horizontal">
-                <div class="row">
-                    <div class="form-group">
-                        <label for="{{ form.name.id_for_label }}" class="col-md-3">{{ form.name.label }}</label>
-                        <div class="col-md-9">
-                            {{ form.name }}
-                            {{ form.name.errors }}
-                        </div>
+            <div class="form-grid">
+                <div class="form-row">
+                    <label for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
+                    <div class="form-field">
+                        {{ form.name }}
+                        {{ form.name.errors }}
                     </div>
                 </div>
-                <div class="row">
-                    <div class="form-group">
-                        <div class="col-md-3"><label>Group Type</label></div>
-                        <div class="col-md-9">
-                                <input id="id_is_open" name="is_open"
+
+                <div class="form-row">
+                    <label>Group Type</label>
+                    <div class="form-field form-field--toggle">
+                        <div class="toggle-options">
+                            <input id="id_is_open" name="is_open"
                                     type="checkbox" checked="checked"
                                     data-toggle="toggle" data-on="Public"
                                     data-off="Private"
                                     data-onstyle="success"
                                     data-offstyle="danger">
-                            {{ form.is_open.errors }}
-                            <p>Tip: Anyone can join a public group. Group owners
-                            approve private group membership requests.</p>
                         </div>
-                        <label for="{{ form.is_open.id_for_label }}" class="col-md-9"></label>
+                        {{ form.is_open.errors }}
+                        <p class="field-tip">Tip: Anyone can join a public group. Group owners approve private group membership requests.</p>
                     </div>
                 </div>
-                <div class="row">
-                    <div class="form-group">
-                        <label for="{{ form.blurb.id_for_label }}" class="col-md-3" class="form-control">Description</label>
-                        <div class="col-md-9">
-                            {{ form.blurb }}
-                            {{ form.blurb.errors }}
-                        </div>
+
+                <div class="form-row">
+                    <label for="{{ form.blurb.id_for_label }}">Description</label>
+                    <div class="form-field">
+                        {{ form.blurb }}
+                        {{ form.blurb.errors }}
                     </div>
                 </div>
-                <div class="row">
-                    <div class="form-group">
-                        <label for="{{ form.image.id_for_label }}" class="col-md-3">{{ form.image.label }}</label>
-                        <div class="col-md-9">
-                            {{ form.image }}<br>
-                            {{ form.image.errors }}
-                            Tip: the best image sizes are 345x195 or larger.
-                        </div>
+
+                <div class="form-row">
+                    <label for="{{ form.image.id_for_label }}">{{ form.image.label }}</label>
+                    <div class="form-field">
+                        {{ form.image }}<br>
+                        {{ form.image.errors }}
+                        <p class="field-tip">Tip: the best image sizes are 345x195 or larger.</p>
                     </div>
                 </div>
             </div>
 
-            <div>
-                <div class="text-right">
-                    <label>
-                        <button class="btn btn-success" type="submit">Create Group</button>
-                    </label>
-                </div>
+            <div class="form-actions">
+                <button class="button-big" type="submit">Create Group</button>
             </div>
         </form>
-
-        <hr>
-        <div style="display:none">
-        </div>
     </div>
-</div>
-
 {% endblock %}
+
 {% block extra_js %}
   {{ block.super }}
   <script src="{% static '/mapgroups/assets/bootstrap-toggle-master/js/bootstrap-toggle.min.js' %}"></script>

--- a/mida/templates/mapgroups/mapgroup_form.html
+++ b/mida/templates/mapgroups/mapgroup_form.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block extra_css %}
+  {{ block.super }}
+  <link href="{% static '/mapgroups/assets/bootstrap-toggle-master/css/bootstrap-toggle.min.css' %}" rel="stylesheet">
+  <link href="{% static '/mapgroups/css/create_map_group_form.css' %}" rel="stylesheet">
+{% endblock %}
+
+{% block page_header %}
+    <a class="btn btn-success" href="{% url 'mapgroups:list'%}">&larr; Groups</a>
+{% endblock %}
+
+{% block content %}
+
+<div>
+    <h2 style="text-align: center;">Create a map group</h2>
+    <div>
+        <hr />
+        <div class="group-form-disclaimer">
+          <p><i>*Note: MARCO reserves the right to review and remove Groups and content shared within them due to inactivity, inappropriate content or other misuse.</i></p>
+        </div>
+
+        <form class="login-form" method="POST" enctype="multipart/form-data">
+            {% csrf_token %}
+            <div class="form-horizontal">
+                <div class="row">
+                    <div class="form-group">
+                        <label for="{{ form.name.id_for_label }}" class="col-md-3">{{ form.name.label }}</label>
+                        <div class="col-md-9">
+                            {{ form.name }}
+                            {{ form.name.errors }}
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="form-group">
+                        <div class="col-md-3"><label>Group Type</label></div>
+                        <div class="col-md-9">
+                                <input id="id_is_open" name="is_open"
+                                    type="checkbox" checked="checked"
+                                    data-toggle="toggle" data-on="Public"
+                                    data-off="Private"
+                                    data-onstyle="success"
+                                    data-offstyle="danger">
+                            {{ form.is_open.errors }}
+                            <p>Tip: Anyone can join a public group. Group owners
+                            approve private group membership requests.</p>
+                        </div>
+                        <label for="{{ form.is_open.id_for_label }}" class="col-md-9"></label>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="form-group">
+                        <label for="{{ form.blurb.id_for_label }}" class="col-md-3" class="form-control">Description</label>
+                        <div class="col-md-9">
+                            {{ form.blurb }}
+                            {{ form.blurb.errors }}
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="form-group">
+                        <label for="{{ form.image.id_for_label }}" class="col-md-3">{{ form.image.label }}</label>
+                        <div class="col-md-9">
+                            {{ form.image }}<br>
+                            {{ form.image.errors }}
+                            Tip: the best image sizes are 345x195 or larger.
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div>
+                <div class="text-right">
+                    <label>
+                        <button class="btn btn-success" type="submit">Create Group</button>
+                    </label>
+                </div>
+            </div>
+        </form>
+
+        <hr>
+        <div style="display:none">
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+{% block extra_js %}
+  {{ block.super }}
+  <script src="{% static '/mapgroups/assets/bootstrap-toggle-master/js/bootstrap-toggle.min.js' %}"></script>
+{% endblock %}


### PR DESCRIPTION
Redesign the create map group form.

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign="top"><img width="100%" height="auto" alt="portal midatlanticocean org_collaborate_groupscreate" src="https://github.com/user-attachments/assets/97bc7ffc-e51f-45a1-88b4-9f2437a4c8e1" />
 <td valign="top">
<img width="100%" height="auto" alt="localhost_8002_collaborate_groupscreate" src="https://github.com/user-attachments/assets/2042bf8f-80f5-4212-97f1-f1f4ed88f7d8" />

</table>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211894077327819