### PR TITLE
Redesign Manage Map Group

### DIFF
--- a/mida/static/mida/css/globals.css
+++ b/mida/static/mida/css/globals.css
@@ -219,14 +219,6 @@ strong {
     text-decoration: none;
 }
 
-.button-red {
-    background-color: var(--red);
-}
-
-.button-green {
-    background-color: var(--green);
-}
-
 .button-big {
     align-items: center;
     background-color: var(--yellow-bright);
@@ -280,4 +272,16 @@ strong {
     background: transparent;
     border: 1px solid var(--dark-blue);
     color: var(--dark-blue);
+}
+
+.button-red {
+    background-color: var(--red);
+}
+
+.button-green {
+    background-color: var(--green);
+}
+
+.button-grey {
+    background-color: var(--gray-medium);
 }

--- a/mida/static/mida/mapgroups/mapgroup_form.css
+++ b/mida/static/mida/mapgroups/mapgroup_form.css
@@ -1,9 +1,9 @@
-.create-map-group h2 {
+.mapgroup-form h2 {
     color: var(--teal);
     text-align: center;
 }
 
-.create-map-group .form-grid {
+.mapgroup-form .form-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1.5rem;
@@ -11,12 +11,13 @@
   width: 80%;
 }
 
-.create-map-group .form-row {
+.mapgroup-form .form-row {
   display: grid;
   gap: 0.5rem;
 }
 
-.create-map-group .form-row > label {
+.mapgroup-form .form-row > label,
+.mapgroup-form .delete-form label {
     font-family: var(--FAQ-headline-font-family);
     font-size: var(--FAQ-headline-font-size);
     line-height: var(--FAQ-headline-line-height);
@@ -24,35 +25,53 @@
     color: var(--dark-blue);
 }
 
-.create-map-group .form-field {
+.mapgroup-form .form-field {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  position: relative;
 }
 
-.create-map-group .form-field--toggle .toggle-options {
+.mapgroup-form .form-field--toggle .toggle-options {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.create-map-group .field-tip {
+.mapgroup-form .field-tip {
   margin: 0;
   font-size: 0.9rem;
   color: #6b7280;
 }
 
-.create-map-group .form-actions {
+.mapgroup-form .form-actions {
   margin-top: 2rem;
   text-align: center;
 }
 
-.create-map-group .form-actions .button-big {
-  margin: 0 auto;
+.mapgroup-form .form-actions .button-big {
+  margin: 1rem auto;
+}
+
+.mapgroup-form .form-actions a {
+    color: var(--dark-blue);
+    text-decoration: underline;
+}
+
+.mapgroup-form .delete-form {
+    background: var(--white);
+    margin: var(--space-9) auto 0 auto;
+    padding: var(--space-7);
+}
+
+.mapgroup-form .remove-image {
+    position: absolute;
+    right: 10px;
+    top: 10px;
 }
 
 @media (min-width: 768px) {
-  .create-map-group .form-row {
+  .mapgroup-form .form-row {
     grid-template-columns: 200px minmax(0, 1fr);
     align-items: start;
   }

--- a/mida/static/mida/mapgroups/mapgroup_form.css
+++ b/mida/static/mida/mapgroups/mapgroup_form.css
@@ -1,6 +1,7 @@
 .mapgroup-form h2 {
     color: var(--teal);
     text-align: center;
+    text-transform: uppercase;
 }
 
 .mapgroup-form .form-grid {

--- a/mida/templates/mapgroups/mapgroup_detail.html
+++ b/mida/templates/mapgroups/mapgroup_detail.html
@@ -11,6 +11,9 @@
 
 {% block page_header %}
 <!-- start page_header -->
+
+    <a class="button-small property-outline" href="{% url 'mapgroups:list'%}">Back to Groups</a>
+    
     <div class="hero-flex-container header-data-groups">
         
         <div class="hero-left group-info">

--- a/mida/templates/mapgroups/mapgroup_edit.html
+++ b/mida/templates/mapgroups/mapgroup_edit.html
@@ -1,0 +1,32 @@
+{% extends "mapgroups/mapgroup_form.html" %}
+{% load static %}
+
+{% block page_header %}
+    <a class="button-small property-outline" href="{% url 'mapgroups:detail' mapgroup.pk mapgroup.slug %}">Back To {{ mapgroup.name }}</a>
+{% endblock %}
+
+    
+{% block mapgroup_form_title %}Manage Your Map Group{% endblock %}
+{% block mapgroup_form_disclaimer %}{% endblock %}
+{% block form_action %}action="{% url 'mapgroups:edit' mapgroup.pk mapgroup.slug %}"{% endblock %}
+
+{% block form_buttons %}
+    <button class="button-big" type="submit">Save Changes</button>
+    <a href="{% url 'mapgroups:detail' mapgroup.pk mapgroup.slug %}">Cancel changes</a>
+{% endblock %}
+    
+{% block additional_forms %}
+    
+    <form class="delete-form" method="POST" action="{% url 'mapgroups:delete' mapgroup.pk mapgroup.slug %}">
+        {% csrf_token %}
+        <label>Delete your group</label>
+        <p class="field-tip">Deleting a group is permanent, and cannot be undone.</p>
+        <button class="button button-red" type="submit"  onclick='return confirm("Are you sure you want to delete your map group “{{ mapgroup.name }}”?")'>Delete group</button>
+    </form>
+
+    <form style="display: none" method="POST" action="{% url 'mapgroups:remove-image' mapgroup.pk mapgroup.slug %}">
+        {% csrf_token %}
+        <input type="submit" id="remove-image-submit">
+    </form>
+{% endblock %}
+

--- a/mida/templates/mapgroups/mapgroup_form.html
+++ b/mida/templates/mapgroups/mapgroup_form.html
@@ -13,16 +13,17 @@
 
 {% block content %}
 
-    <section class="create-map-group">
-        <div class="create-map-group contain">
-            <h2>Create a map group</h2>
+    <section class="mapgroup-form">
+        
+        <div class="contain">
+            <h2>{% block mapgroup_form_title %}Create a map group{% endblock %}</h2>
             <div class="group-form-disclaimer">
-                <p><i>*Note: MARCO reserves the right to review and remove Groups and content shared within them due to inactivity, inappropriate content or other misuse.</i></p>
+                <p>{% block mapgroup_form_disclaimer %}<i>*Note: MARCO reserves the right to review and remove Groups and content shared within them due to inactivity, inappropriate content or other misuse.</i>{% endblock %}</p>
             </div>
         </div>
 
         <div class="bg-light-blue contain contain-padded">
-            <form class="create-group-form" method="POST" enctype="multipart/form-data">
+            <form class="create-group-form" method="POST" enctype="multipart/form-data" {% block form_action %}{% endblock %}>
                 {% csrf_token %}
                 <div class="form-grid">
                     <div class="form-row">
@@ -60,6 +61,12 @@
                     <div class="form-row">
                         <label for="{{ form.image.id_for_label }}">{{ form.image.label }}</label>
                         <div class="form-field">
+                            {% if mapgroup.image %}
+                                <label for=remove-image-submit class="button button-red remove-image">Remove Image</label>
+                            {% endif %}
+                            {% if mapgroup.image_url %}
+                                <img src="{{ mapgroup.image_url }}" style="width: 100%">
+                            {% endif %}
                             {{ form.image }}<br>
                             {{ form.image.errors }}
                             <p class="field-tip">Tip: the best image sizes are 345x195 or larger.</p>
@@ -68,9 +75,14 @@
                 </div>
 
                 <div class="form-actions">
-                    <button class="button-big" type="submit">Create Group</button>
+                    {% block form_buttons %}
+                        <button class="button-big" type="submit">Create Group</button>
+                    {% endblock %}
                 </div>
             </form>
+
+            {% block additional_forms %}{% endblock %}
+
         </div>
     </section>
 {% endblock %}

--- a/mida/templates/mapgroups/mapgroup_form.html
+++ b/mida/templates/mapgroups/mapgroup_form.html
@@ -65,7 +65,7 @@
                                 <label for=remove-image-submit class="button button-red remove-image">Remove Image</label>
                             {% endif %}
                             {% if mapgroup.image_url %}
-                                <img src="{{ mapgroup.image_url }}" alt="{{ mapgroup.name }} group image" style="width: 100%">
+                                <img src="{{ mapgroup.image_url }}" class="current-image" alt="current group image"/>
                             {% endif %}
                             {{ form.image }}<br>
                             {{ form.image.errors }}

--- a/mida/templates/mapgroups/mapgroup_form.html
+++ b/mida/templates/mapgroups/mapgroup_form.html
@@ -65,7 +65,7 @@
                                 <label for=remove-image-submit class="button button-red remove-image">Remove Image</label>
                             {% endif %}
                             {% if mapgroup.image_url %}
-                                <img src="{{ mapgroup.image_url }}" style="width: 100%">
+                                <img src="{{ mapgroup.image_url }}" alt="{{ mapgroup.name }} group image" style="width: 100%">
                             {% endif %}
                             {{ form.image }}<br>
                             {{ form.image.errors }}


### PR DESCRIPTION
Manage map group redesign

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td valign="top">
<img width="2218" height="3498" alt="portal midatlanticocean org_collaborate_groups123_davids-group_edit" src="https://github.com/user-attachments/assets/44323834-09e6-47ad-9c82-94c6ebebdc14" />
 <td valign="top">
<img width="2218" height="6000" alt="localhost_8002_collaborate_groups119_the-theme-children_edit" src="https://github.com/user-attachments/assets/18b51cfa-eac8-4786-9b80-1bdaa895437e" />

</table>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211894077327820