### PR TITLE
Redesign Manage Group 2

### DIFF
--- a/mida/static/mida/mapgroups/mapgroup_detail.css
+++ b/mida/static/mida/mapgroups/mapgroup_detail.css
@@ -5,7 +5,11 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: clamp(1.5rem, 3vw, 2.5rem);
+    gap: clamp(.5rem, 1vw, 1rem);
+}
+
+.header-data-groups .title-line {
+    margin-top: 1rem;
 }
 
 .header-data-groups .title-line h4 {

--- a/mida/templates/mapgroups/mapgroup_detail.html
+++ b/mida/templates/mapgroups/mapgroup_detail.html
@@ -11,13 +11,13 @@
 
 {% block page_header %}
 <!-- start page_header -->
-
-    <a class="button-small property-outline" href="{% url 'mapgroups:list'%}">Back to Groups</a>
     
     <div class="hero-flex-container header-data-groups">
         
         <div class="hero-left group-info">
-        
+            
+            <a class="button-small property-outline" href="{% url 'mapgroups:list'%}">Back to Groups</a>
+
             <div class="title-line">
                 <div class="over-title margin-bottom-3">
                     {% if mapgroup.is_open %}


### PR DESCRIPTION
Single change that repositions the `Back to Groups` button for improved visual spacing.