### PR TITLE
Refactor Featured Image Sizes

### DIFF
--- a/mida/templates/calendar/calendar.html
+++ b/mida/templates/calendar/calendar.html
@@ -13,7 +13,7 @@
                 <article class="event-card">
                     {% if item.feature_image %}
                         <a class="event-card__media" href="{{ item.url }}">
-                            {% image item.feature_image fill-640x420 class="event-card__image" %}
+                            {% image item.feature_image min-640x420 class="event-card__image" %}
                         </a>
                     {% endif %}
 

--- a/mida/templates/calendar/event.html
+++ b/mida/templates/calendar/event.html
@@ -66,11 +66,15 @@
         </div>
 
         {% if self.feature_image %}
+      
+            {% image self.feature_image min-520x430 as feat_img %}
+            
             <div class="hero-right">
-                <div class="hero-image-wrap" style="background-image: url('{{ self.feature_image.file.url }}');">
-                    {% image self.feature_image fill-520x430 class="feature" alt="{{ self.display_name }}" %}
+                <div class="hero-image-wrap" style="background-image: url('{{ feat_img.url }}');">
+                    <img class="feature" src="{{ feat_img.url }}" alt="{{ self.title }}" />
                 </div>
             </div>
+        
         {% endif %}
 
     </div>

--- a/mida/templates/data_catalog/theme.html
+++ b/mida/templates/data_catalog/theme.html
@@ -44,11 +44,15 @@
         </div>
         
         {% if theme.wagtail_feature_image %}
+
+            {% image theme.wagtail_feature_image min-520x430 as feat_img %}
+      
             <div class="hero-right">
-                <div class="hero-image-wrap" style="background-image: url('{{ theme.wagtail_feature_image.file.url }}');">
-                    {% image theme.wagtail_feature_image fill-520x430 class="feature" alt="{{ theme.display_name }}" %}
+                <div class="hero-image-wrap" style="background-image: url('{{ feat_img.url }}');">
+                <img class="feature" src="{{ feat_img.url }}" alt="{{ theme.display_name }}" />
                 </div>
             </div>
+            
         {% endif %}
         
     </div>

--- a/mida/templates/news/story.html
+++ b/mida/templates/news/story.html
@@ -43,12 +43,18 @@
         </div>
         
         {% if self.feature_image %}
+      
+            {% image self.feature_image fill-520x430 as feat_img %}
+            
             <div class="hero-right">
-                <div class="hero-image-wrap" style="background-image: url('{{ self.feature_image.file.url }}');">
-                    {% image self.feature_image fill-520x430 class="feature" alt="{{ self.display_name }}" %}
+                <div class="hero-image-wrap" style="background-image: url('{{ feat_img.url }}');">
+                    <img class="feature" src="{{ feat_img.url }}" alt="{{ self.title }}" />
                 </div>
             </div>
+            
         {% endif %}
+
+        
         
     </div>
 

--- a/mida/templates/ocean_stories/ocean_story.html
+++ b/mida/templates/ocean_stories/ocean_story.html
@@ -29,13 +29,17 @@
                 <a class="button-big" href="{{ self.explore_url }}" title="{{ self.explore_title }}" target="_blank">{{ self.explore_title }}</a>
             </h7>
         </div>
-        
+
         {% if self.feature_image %}
+      
+            {% image self.feature_image min-520x430 as feat_img %}
+            
             <div class="hero-right">
-                <div class="hero-image-wrap" style="background-image: url('{{ self.feature_image.file.url }}');">
-                    {% image self.feature_image fill-520x430 class="feature" alt="{{ self.display_name }}" %}
+                <div class="hero-image-wrap" style="background-image: url('{{ feat_img.url }}');">
+                    <img class="feature" src="{{ feat_img.url }}" alt="{{ self.title }}" />
                 </div>
             </div>
+        
         {% endif %}
         
     </div>


### PR DESCRIPTION
**Image rendering improvements:**

* Updated the image filter from `fill` to `min` for feature images in `calendar.html`, likely to ensure images are not cropped and maintain minimum dimensions.
* In `event.html`, `theme.html`, `story.html`, and `ocean_story.html`, refactored image rendering to:
  - Assign the processed image to a template variable (e.g., `feat_img`)
  - Use the image URL for both the background and the `<img>` tag, improving consistency and potentially performance
  - Standardize the use of `min-520x430` or `fill-520x430` filters as appropriate for each template [[1]](diffhunk://#diff-c350e16a8e4a5aee6ef8dd2ca0da3f3901b8e5de783844b331a3c42e1b32b69cR69-R77) [[2]](diffhunk://#diff-9255e9b2c2b7c411346a475e2e76718dc873a81ca2ef0063fe381b7ef07a3261R47-R55) [[3]](diffhunk://#diff-c4df8d7a465b4c83323f1c5eccc9616acb278f144fac86159f1127aa1115d286R46-R58) [[4]](diffhunk://#diff-227b0a6e2ed751cf3229479a4ca16658a5fca99bf5517114c019622f84862b29R34-R42)