### PR TITLE
Redesign register page

### DIFF
--- a/mida/templates/accounts/register.html
+++ b/mida/templates/accounts/register.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block extra_css %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static 'mida/accounts/accounts.css' %}">
+{% endblock %}
+
+{% block body_class %}accounts register-page{% endblock %}
+
+{% block content %}
+    
+    <script src='https://www.google.com/recaptcha/api.js'></script>
+
+    <section class="contain login">
+
+        <h2 class="login-header">SIGN UP</h2>
+
+        <p>Unlock the full potential of the Portal by becoming a registered user.</p>
+
+        <form class="login-form" id="register-form" method="POST" action="{% url 'account:register' %}#form-begin">
+            {% csrf_token %}
+
+            {{ form.as_div }}
+
+            <button class="button-big" onclick='this.form.submit()'>Sign Up &rarr;</button>
+        </form>
+
+    </section>
+
+{% endblock %}
+

--- a/mida/templates/accounts/register.html
+++ b/mida/templates/accounts/register.html
@@ -26,6 +26,10 @@
             <button class="button-big" onclick='this.form.submit()'>Sign Up &rarr;</button>
         </form>
 
+        <div class="account-links">
+            <a href="/help/">Need Help?</a>
+        </div>
+
     </section>
 
 {% endblock %}


### PR DESCRIPTION
Please Note:
* I made a few design decisions on this page that diverge from the Figma redesign:
	1. I did not include the Welcome Snippet, bc it does not feel like the right place for this content. The user is already on the sign up page, so why is there content trying to get someone to sign up. 
	2. I did not include the forgot password link. I hope the reason is obvious
* The ReCaptcha looks broken bc my localhost is not setup for this ReCaptcha API

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td valign="top">
<img width="2254" height="3716" alt="portal midatlanticocean org_accountregister_" src="https://github.com/user-attachments/assets/f780b58f-7e0f-4ff9-9ca0-b5228ec208b0" />

 <td valign="top">
<img width="2254" height="5004" alt="localhost_8002_accountregister_" src="https://github.com/user-attachments/assets/4795793e-fd8d-44a8-9d60-b2d8fa0ba4a7" />

</table>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212353167439998