### PR TITLE
Refactor CMS

### DIFF
--- a/mida/static/mida/cms/style.css
+++ b/mida/static/mida/cms/style.css
@@ -57,6 +57,12 @@
     line-height: var(--p1-line-height);
 }
 
+.cms-page .page-body p {
+    font-family: var(--p3-font-family);
+    font-weight: var(--p3-font-weight);
+    font-size: var(--p3-font-size);
+    line-height: var(--p3-line-height);
+}
 
 @media (min-width: 48rem) {
     .hero-flex-container {

--- a/mida/static/mida/css/globals.css
+++ b/mida/static/mida/css/globals.css
@@ -197,9 +197,6 @@ em {
     font-style: italic;
 }
 
-br {
-
-}
 
 strong,
 b {

--- a/mida/static/mida/css/globals.css
+++ b/mida/static/mida/css/globals.css
@@ -193,18 +193,16 @@ p {
     line-height: var(--p1-line-height);
 }
 
-.page-body p {
-    font-family: var(--p3-font-family);
-    font-weight: var(--p3-font-weight);
-    font-size: var(--p3-font-size);
-    line-height: var(--p3-line-height);
-}
-
 em {
     font-style: italic;
 }
 
-strong {
+br {
+
+}
+
+strong,
+b {
     font-weight: bold;
 }
 

--- a/mida/templates/cms/section.html
+++ b/mida/templates/cms/section.html
@@ -2,6 +2,8 @@
 {% extends "cms/base.html" %}
 {% load wagtailimages_tags wagtailcore_tags wagtailcustom_tags %}
 
+{% block body_class %}cms-page{% endblock %}
+
 {% block layout %}section{% endblock %}
 
 {% block page_header %}


### PR DESCRIPTION
This pull request updates the styling and template structure for CMS pages, specifically refining how paragraph text is styled and ensuring the correct CSS is applied in the appropriate context. The main changes involve moving paragraph styling from a global stylesheet to a CMS-specific stylesheet, updating the body class in the template, and making minor adjustments to global styles.

Styling and template updates for CMS pages:

* Moved the `.page-body p` paragraph styling (font family, weight, size, and line height) from the global stylesheet `globals.css` to the CMS-specific stylesheet `cms/style.css`, and scoped it under `.cms-page .page-body p` for better encapsulation. [[1]](diffhunk://#diff-2602478235c0d754fd81799961c15723043eb43b1e63cccdbe7eb3638f037343L196-R205) [[2]](diffhunk://#diff-0bc46e16bca3620e031483e11e9c39c5addc44b7e548d591696e2ed71bd44aabR60-R65)
* Updated the `section.html` template to set the `body_class` block to `cms-page`, ensuring the new CMS-specific styles are applied correctly.

Global style adjustments:

* Changed the selector for bold text in `globals.css` to include both `strong` and `b` elements, and removed an unnecessary empty `br` rule.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212378577442775