### PR TITLE
Add fallback image for news posts

### DIFF
--- a/mida/templates/components/card-post/index.html
+++ b/mida/templates/components/card-post/index.html
@@ -10,7 +10,11 @@
     {% if item.feature_image %}
         <div class="img-wrapper">
             <a href="{{ item.url }}">
-                {% image item.feature_image fill-355x195 class="feature" alt="{{ item.title }}" %}
+                {% if item.feature_image %}
+                    {% image item.feature_image fill-355x195 class="feature" %}
+                {% else %}
+                    <img class="feature" src="{% static 'mida/components/card-post/img/marcodataportal-homepage-image09.png' %}" alt="Image placeholder" />
+                {% endif %}
             </a>
             <time class="date" datetime="{{ item.posted|date:"Y-m-d" }}">
                 <img class="calendar-icon" src="{% static 'mida/components/card-post/img/marcodataportal-global-icon-calendar.svg' %}" alt="" aria-hidden="true" />


### PR DESCRIPTION
Adds a fallback image for news posts without a featured image.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212573204246820