### PR TITLE
Commented out including breadcrumbs due to disconnect between designers and content authors.

### DIFF
--- a/mida/templates/cms/base.html
+++ b/mida/templates/cms/base.html
@@ -44,7 +44,11 @@
 
   </div>
 
-  {% include 'components/breadcrumb/index.html' %}
+  <!-- 
+    Commented out including breadcrumbs due to disconnect between designers and content authors.
+    Breadcrumbs are in the Figma redesign's, but the information architecture for user friendly page titles does not exist. 
+    {% include 'components/breadcrumb/index.html' %}
+  -->
 
 {% endblock %}
 

--- a/mida/templates/cms/base.html
+++ b/mida/templates/cms/base.html
@@ -47,8 +47,8 @@
   <!-- 
     Commented out including breadcrumbs due to disconnect between designers and content authors.
     Breadcrumbs are in the Figma redesign's, but the information architecture for user friendly page titles does not exist. 
-    {% include 'components/breadcrumb/index.html' %}
   -->
+    {% comment %} {% include 'components/breadcrumb/index.html' %} {% endcomment %}
 
 {% endblock %}
 

--- a/mida/templates/cms/base.html
+++ b/mida/templates/cms/base.html
@@ -46,7 +46,7 @@
 
   <!-- 
     Commented out including breadcrumbs due to disconnect between designers and content authors.
-    Breadcrumbs are in the Figma redesign's, but the information architecture for user friendly page titles does not exist. 
+    Breadcrumbs are in the Figma redesigns, but the information architecture for user friendly page titles does not exist. 
   -->
     {% comment %} {% include 'components/breadcrumb/index.html' %} {% endcomment %}
 


### PR DESCRIPTION
Breadcrumbs are in the Figma redesign's, but the information architecture for user friendly page titles does not exist. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212500646360145