### PR TITLE
Refactor ocean story media

### DIFF
--- a/mida/static/mida/ocean_stories/ocean_story.css
+++ b/mida/static/mida/ocean_stories/ocean_story.css
@@ -158,6 +158,8 @@
 
 .ocean-story .content h2 {
     color: var(--color-ink, #030B39);
+    clear: both;
+    display: block;
     font-family: var(--h4-font-family);
     font-size: var(--h4-font-size);
     font-weight: var(--h4-font-weight);
@@ -167,6 +169,10 @@
 
 .ocean-story .content h2:empty {
     display: none;
+}
+
+.ocean-story .content h3 {
+    clear: both;
 }
 
 .ocean-story .content h3,
@@ -260,6 +266,27 @@
     margin: var(--space-9) auto;
 }
 
+/* Sections with media on the right or left */
+.ocean-story .story-with-media-right,
+.ocean-story .story-with-media-left {
+    display: flex;
+    gap: var(--space-7);
+    align-items: flex-start;
+    justify-content: center;
+}
+
+.ocean-story .story-with-media-right {
+    flex-direction: row-reverse;
+}
+
+.ocean-story .story-with-media-right .story-media-right,
+.ocean-story .story-with-media-left .story-media-left,
+.ocean-story .story-with-media-right .story-media-body,
+.ocean-story .story-with-media-left .story-media-body {
+    flex: 1;
+    margin-top: 0;
+}
+
 .ocean-story .story-media-right,
 .ocean-story .story-media-left {
     margin: var(--space-9) auto;
@@ -277,6 +304,25 @@
 
 .ocean-story .has-legend .media-object {
     display: inline; /* So that media does not extend beyond its container */
+}
+
+/* Rich text media */
+.ocean-story img.richtext-image.full-width {
+    display: block;
+    margin: var(--space-9) auto;
+    max-width: 100%;
+}
+
+.ocean-story img.richtext-image.left {
+    float: left;
+    margin: 0 var(--space-5) var(--space-9) 0;
+    max-width: 50%;
+}
+
+.ocean-story img.richtext-image.right {
+    float: right;
+    margin: 0 0 var(--space-9) var(--space-5);
+    max-width: 50%;
 }
 
 @-webkit-keyframes bounce {

--- a/mida/templates/ocean_stories/content.html
+++ b/mida/templates/ocean_stories/content.html
@@ -217,6 +217,14 @@
                             {% endif %}
                         {% endif %}
 
+                        {% if section.media_position == 'full' %}
+                            {% if section.media_image or section.media_embed_url %}
+                                <div class="media-full">
+                                    {% include "ocean_stories/include_media.html" with item=section only %}
+                                </div>
+                            {% endif %}
+                        {% endif %}
+
                         <div class="story-media-body">
                             <div class="item-text">
                                 {% block body %}
@@ -226,14 +234,6 @@
                                 {% endblock %}
                             </div>
                         </div>
-
-                        {% if section.media_position == 'full' %}
-                            {% if section.media_image or section.media_embed_url %}
-                                <div class="media-full">
-                                    {% include "ocean_stories/include_media.html" with item=section only %}
-                                </div>
-                            {% endif %}
-                        {% endif %}
 
                         {% if section.media_position == 'left' and section.media_image %}
                             </div>


### PR DESCRIPTION
The main changes enhance the flexibility and visual consistency of sections with media content and improve the display of headings and images within the stories.

**Layout and Media Enhancements:**

* Added new CSS classes (`story-with-media-right`, `story-with-media-left`) to enable flexible, side-by-side layouts for sections with media on the right or left, using flexbox for alignment and spacing.
* Improved styling for rich text images by introducing `.richtext-image.full-width`, `.richtext-image.left`, and `.richtext-image.right` classes to control image alignment, margins, and maximum widths for different image placements.

**Heading and Content Formatting:**

* Updated CSS for `.ocean-story .content h2` and `.ocean-story .content h3` to ensure headings clear floated elements, preventing layout issues when images or other floated content are present. [[1]](diffhunk://#diff-f04c8cb6f6093d32422824a7e44dc69d06f791427ef55c17e3605db3d0d576dfR161-R162) [[2]](diffhunk://#diff-f04c8cb6f6093d32422824a7e44dc69d06f791427ef55c17e3605db3d0d576dfR174-R177)

**Template Adjustments:**

* Moved the rendering of full-width media (`media_position == 'full'`) in the `content.html` template to ensure it appears before the main body content, improving content flow and consistency. [[1]](diffhunk://#diff-fa77ba33aa12e78c388048ab5221152e58aa8587eaf51167355d1d13c595155bR220-R227) [[2]](diffhunk://#diff-fa77ba33aa12e78c388048ab5221152e58aa8587eaf51167355d1d13c595155bL230-L237)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212500646360149