### PR TITLE
Fix bullet and discovery tab issues

### DIFF
--- a/mida/static/mida/components/accordion-datacatalog/style.css
+++ b/mida/static/mida/components/accordion-datacatalog/style.css
@@ -104,11 +104,35 @@
     padding: 24px;
 }
 
+.data-datacatalog ul, 
+.data-datacatalog ol {
+    padding-left: 1.5em;
+    margin: var(--space-5) 0;
+    font: inherit;
+}
+
+.data-datacatalog ul {
+    list-style: disc;
+}
+
+.data-datacatalog ol {
+    list-style: decimal;
+}
 
 /* Removed duplicate .div class selector. See lines 108-118 for the consolidated definition. */
 .map-icon {
     width: 18px;
     height: 24px;
+}
+
+.data-datacatalog {
+    font-family: var(--p3-font-family);
+    font-weight: var(--p3-font-weight);
+    color: var(--grey-dark);
+    font-size: var(--p3-font-size);
+    letter-spacing: var(--p3-letter-spacing);
+    line-height: var(--p3-line-height);
+    font-style: var(--p3-font-style);
 }
 
 .frame-2 {

--- a/mida/static/mida/components/tabs-iconsgo/img/marcodataportal-data-mapanddataresources-icon-how tuesday.svg
+++ b/mida/static/mida/components/tabs-iconsgo/img/marcodataportal-data-mapanddataresources-icon-how tuesday.svg
@@ -1,0 +1,32 @@
+<svg width="100" height="100" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="8" y="10" width="40" height="32" rx="2" fill="#F5F6F6" />
+    <rect x="8" y="10" width="40" height="32" rx="2" stroke="#A9B7C7" strokeWidth="2" />
+    
+    <rect x="24" y="42" width="8" height="4" fill="#A9B7C7" />
+    <rect x="18" y="46" width="20" height="2" rx="1" fill="#A9B7C7" />
+    
+    <rect x="8" y="10" width="40" height="6" fill="#7D9AC7" />
+    <circle cx="13" cy="13" r="1.5" fill="#E8ECF7" />
+    <circle cx="17" cy="13" r="1.5" fill="#E8ECF7" />
+    <circle cx="21" cy="13" r="1.5" fill="#E8ECF7" />
+    
+    <g>
+        <circle cx="18" cy="24" r="4" stroke="#7D9AC7" strokeWidth="2" fill="none" />
+        <line x1="21" y1="27" x2="24" y2="30" stroke="#7D9AC7" strokeWidth="2" strokeLinecap="round" />
+        
+        <circle cx="28" cy="24" r="3.5" stroke="#7D9AC7" strokeWidth="1.5" fill="none" />
+        <circle cx="28" cy="24" r="1.5" fill="#7D9AC7" />
+        <line x1="28" y1="19" x2="28" y2="20.5" stroke="#7D9AC7" strokeWidth="1.5" strokeLinecap="round" />
+        <line x1="28" y1="27.5" x2="28" y2="29" stroke="#7D9AC7" strokeWidth="1.5" strokeLinecap="round" />
+        <line x1="33" y1="24" x2="31.5" y2="24" stroke="#7D9AC7" strokeWidth="1.5" strokeLinecap="round" />
+        <line x1="24.5" y1="24" x2="23" y2="24" stroke="#7D9AC7" strokeWidth="1.5" strokeLinecap="round" />
+    
+        <rect x="34" y="28" width="3" height="8" rx="1" fill="#7D9AC7" />
+        <rect x="38" y="24" width="3" height="12" rx="1" fill="#7D9AC7" />
+        <rect x="42" y="26" width="3" height="10" rx="1" fill="#7D9AC7" />
+    </g>
+    
+    <g transform="translate(16, 32)">
+        <path d="M0 0 L5 0 L5 6 L2.5 4.5 L0 6 Z" fill="#7D9AC7" />
+    </g>
+</svg>

--- a/mida/static/mida/components/tabs-iconsgo/style.css
+++ b/mida/static/mida/components/tabs-iconsgo/style.css
@@ -76,7 +76,7 @@
   height: 100%;
 }
 
-iframe { 
+.box-tabs-iconsgo iframe { 
   border: none;
   display: block;
   height: 500px;
@@ -102,7 +102,7 @@ iframe {
     border-bottom: none;
   }
 
-  iframe {
+  .box-tabs-iconsgo iframe {
     height: 400px;
   }
 }
@@ -129,7 +129,7 @@ iframe {
     margin-bottom: 0px;
   }
 
-  iframe {
+  .box-tabs-iconsgo iframe {
     height: 300px;
   }
 }

--- a/mida/static/mida/components/tabs-iconsgo/style.css
+++ b/mida/static/mida/components/tabs-iconsgo/style.css
@@ -76,6 +76,15 @@
   height: 100%;
 }
 
+iframe { 
+  border: none;
+  display: block;
+  height: 500px;
+  margin: 0 auto;
+  max-width: 900px;
+  width: 100%;
+}
+
 @media (max-width: 1240px) {
   .frame {
     flex-wrap: wrap;
@@ -91,6 +100,10 @@
 
   .tab-item:last-child .tab-button {
     border-bottom: none;
+  }
+
+  iframe {
+    height: 400px;
   }
 }
 
@@ -114,5 +127,9 @@
     height: 30px;
     margin-right: 8px;
     margin-bottom: 0px;
+  }
+
+  iframe {
+    height: 300px;
   }
 }

--- a/mida/templates/components/tabs-iconsgo/index.html
+++ b/mida/templates/components/tabs-iconsgo/index.html
@@ -1,5 +1,5 @@
 <!-- mida/templates/components/tabs-iconsgo/index.html -->
-{% load static wagtailcore_tags wagtailimages_tags %}
+{% load static wagtailcore_tags wagtailimages_tags wagtailembeds_tags %}
 
 {% block extra_css %}
     <link rel="stylesheet" href="{% static 'mida/components/tabs-iconsgo/style.css' %}">
@@ -8,29 +8,28 @@
 
 
 <div class="box-tabs-iconsgo">
-    <nav class="tabs" aria-label="Data resource categories">
-      <ul class="frame">
-        {% for section in sections %}
-          <li class="tab-item">
-            <a href="#{{ section.title|lower}}" class="tab-button" aria-selected="false" role="tab">
-              <img class="tab-icon" src="{% static 'mida/components/tabs-iconsgo/img/marcodataportal-data-mapanddataresources-icon-'|add:section.title|lower|add:'.svg' %}"
-                alt="{{ section.title }} icon" />
-              <span class="tab-text">{{ section.title }}</span>
-            </a>
-          </li>
-        {% endfor %}
-      </ul>
-    </nav>
-    
-    {% for item in sections %}
-      <div class="tabs-link-container" id="{{ item.title|slugify }}">    
-        <article class="link-wrapper">
-            <p>{{ item.body|safe }}</p>
-        </article>
-      </div>
-    {% endfor %}
+  <nav class="tabs" aria-label="Data resource categories">
+    <ul class="frame">
+      {% for section in sections %}
+        <li class="tab-item">
+          <a href="#{{ section.title|lower}}" class="tab-button" aria-selected="false" role="tab">
+            <img class="tab-icon" src="{% static 'mida/components/tabs-iconsgo/img/marcodataportal-data-mapanddataresources-icon-'|add:section.title|lower|add:'.svg' %}" alt="{{ section.title }} icon" />
+            <span class="tab-text">{{ section.title }}</span>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
+  
+  {% for item in sections %}
+    <div class="tabs-link-container" id="{{ item.title|slugify }}">    
+      <article class="link-wrapper">
+          {{ item.body|richtext }}
+      </article>
+    </div>
+  {% endfor %}
 
-  </div>
+</div>
 
 {% block extra_js %}
   <script src="{% static 'mida/components/tabs-iconsgo/scripts.js' %}"></script>

--- a/mida/templates/components/tabs-iconsgo/index.html
+++ b/mida/templates/components/tabs-iconsgo/index.html
@@ -1,5 +1,5 @@
 <!-- mida/templates/components/tabs-iconsgo/index.html -->
-{% load static wagtailcore_tags wagtailimages_tags wagtailembeds_tags %}
+{% load static wagtailcore_tags wagtailimages_tags %}
 
 {% block extra_css %}
     <link rel="stylesheet" href="{% static 'mida/components/tabs-iconsgo/style.css' %}">


### PR DESCRIPTION
This pull request introduces improvements to the styling and rendering of list and embedded content in the data catalog and tabs components. The most significant changes include enhanced list styling for the data catalog, better iframe handling and responsiveness in the tabs component, and improved rich text rendering in the tabs template.

**Styling and rendering enhancements:**

* Improved list styling for `.data-datacatalog` elements by adding custom styles for `ul` and `ol`, including indentation, spacing, and list markers, and consolidated font styling for consistent appearance.
* Enhanced iframe display in the tabs component by adding default styles for size, centering, and border removal, and made iframe height responsive for different screen widths via media queries. [[1]](diffhunk://#diff-84aa1fa0a56cee08e1e14301434ee3c5d974c265a516d04d3bf6e848eb6db6b4R79-R87) [[2]](diffhunk://#diff-84aa1fa0a56cee08e1e14301434ee3c5d974c265a516d04d3bf6e848eb6db6b4R104-R107) [[3]](diffhunk://#diff-84aa1fa0a56cee08e1e14301434ee3c5d974c265a516d04d3bf6e848eb6db6b4R131-R134)

**Template and rendering improvements:**

* Updated the tabs template to use `richtext` rendering for section bodies, enabling better formatting and embedded content support.
* Added the `wagtailembeds_tags` template tag to support embedded content in the tabs template.

**Minor code cleanup:**

* Minor formatting improvement for the tab icon image element for readability.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213423810984931