### PR TITLE
support raw HTML in top-level theme descriptions

### DIFF
--- a/mida/templates/data_catalog/theme.html
+++ b/mida/templates/data_catalog/theme.html
@@ -27,7 +27,7 @@
             
             {% if theme.description %}
                 <div class="description">
-                    <p>{{ theme.description }}</p>
+                    <p>{{ theme.description|safe }}</p>
                 </div>
             {% endif %}
 


### PR DESCRIPTION
Literally 1 line.

MARCO wants custom language with links to working groups in a few particular top-level Themes. Simply adding `|safe` to the description template tag seems to get everything we need to make everyone happy. 

Granted, inserting raw HTML into ANY Theme may be a bad idea, as those descriptions should show when users click on the 'i' icon next to themes in the layer picker to the left of the map. Those might already support HTML, too, but I'm holding that as outside of scope ATM. Top-level Themes do not show their descriptions in the 'Visualize' tool (yet).